### PR TITLE
Fix: Unescaped left brace in regex is illegal

### DIFF
--- a/check_backuppc_hosts.pl
+++ b/check_backuppc_hosts.pl
@@ -104,7 +104,7 @@ sub check_hosts_status
        		chomp $_;
 	       	my $current_host;
 	        # Add host to hosts_list
-       		if (/"(\S+)" => {/)
+       		if (/"(\S+)" => \{/)
        		{
 	        	push @hosts_list, $1;
            		$current_host=$1;


### PR DESCRIPTION
I stumbled across this after updating from Ubuntu 16.04 to 18.04, and other than tweaking my sudoers config, no other changes were required. I was running v0.2 which has been working perfectly for as long as I can remember, and probably before that!